### PR TITLE
Add dark mode with Catppuccin Mocha theme

### DIFF
--- a/about.html
+++ b/about.html
@@ -23,6 +23,15 @@
 
   <!-- Styles -->
   <link rel="stylesheet" href="css/style.css">
+
+  <!-- Prevent FOUC for theme -->
+  <script>
+    (function() {
+      const stored = localStorage.getItem('theme');
+      const preferred = stored || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+      document.documentElement.setAttribute('data-theme', preferred);
+    })();
+  </script>
 </head>
 <body>
   <header class="header">
@@ -32,6 +41,27 @@
         <li><a href="index.html" class="nav__link">Index</a></li>
         <li><a href="about.html" class="nav__link nav__link--active">About</a></li>
         <li><a href="research.html" class="nav__link">Research</a></li>
+        <li>
+          <button class="theme-toggle" id="theme-toggle" aria-label="Toggle dark mode">
+            <span class="theme-toggle__track"></span>
+            <span class="theme-toggle__thumb">
+              <svg class="theme-toggle__icon theme-toggle__icon--moon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+              </svg>
+              <svg class="theme-toggle__icon theme-toggle__icon--sun" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <circle cx="12" cy="12" r="5"/>
+                <line x1="12" y1="1" x2="12" y2="3" stroke="currentColor" stroke-width="2"/>
+                <line x1="12" y1="21" x2="12" y2="23" stroke="currentColor" stroke-width="2"/>
+                <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" stroke="currentColor" stroke-width="2"/>
+                <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" stroke="currentColor" stroke-width="2"/>
+                <line x1="1" y1="12" x2="3" y2="12" stroke="currentColor" stroke-width="2"/>
+                <line x1="21" y1="12" x2="23" y2="12" stroke="currentColor" stroke-width="2"/>
+                <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" stroke="currentColor" stroke-width="2"/>
+                <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" stroke="currentColor" stroke-width="2"/>
+              </svg>
+            </span>
+          </button>
+        </li>
       </ul>
     </nav>
   </header>

--- a/css/style.css
+++ b/css/style.css
@@ -46,6 +46,28 @@
 }
 
 /* ═══════════════════════════════════════════════════════════════════════════
+   DARK MODE - Catppuccin Mocha
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+[data-theme="dark"] {
+  --color-paper: #1e1e2e;
+  --color-white: #cdd6f4;
+  --color-ink: #cdd6f4;
+  --color-ink-muted: #a6adc8;
+  --color-ink-light: #6c7086;
+  --color-border: #45475a;
+  --color-border-light: #313244;
+  --color-surface: #181825;
+  --color-accent: #89b4fa;
+  --color-accent-hover: #b4befe;
+}
+
+[data-theme="dark"] ::selection {
+  background-color: var(--color-accent);
+  color: var(--color-surface);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
    RESET
    ═══════════════════════════════════════════════════════════════════════════ */
 
@@ -240,8 +262,84 @@ pre code {
 
 .nav__links {
   display: flex;
+  align-items: center;
   gap: var(--space-lg);
   list-style: none;
+}
+
+/* Theme Toggle */
+.theme-toggle {
+  position: relative;
+  width: 44px;
+  height: 22px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 11px;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease;
+  padding: 0;
+  margin-left: var(--space-sm);
+}
+
+.theme-toggle:hover {
+  border-color: var(--color-ink-muted);
+}
+
+.theme-toggle:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--color-accent);
+}
+
+.theme-toggle__track {
+  position: absolute;
+  inset: 2px;
+  border-radius: 8px;
+}
+
+.theme-toggle__thumb {
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 14px;
+  height: 14px;
+  background: var(--color-ink);
+  border-radius: 50%;
+  transition: transform 0.2s ease, background 0.2s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.theme-toggle__icon {
+  width: 10px;
+  height: 10px;
+  fill: var(--color-paper);
+  transition: opacity 0.15s ease;
+}
+
+.theme-toggle__icon--moon {
+  display: block;
+}
+
+.theme-toggle__icon--sun {
+  display: none;
+}
+
+[data-theme="dark"] .theme-toggle {
+  background: var(--color-surface);
+}
+
+[data-theme="dark"] .theme-toggle__thumb {
+  transform: translateX(22px);
+  background: var(--color-accent);
+}
+
+[data-theme="dark"] .theme-toggle__icon--moon {
+  display: none;
+}
+
+[data-theme="dark"] .theme-toggle__icon--sun {
+  display: block;
 }
 
 .nav__link {

--- a/index.html
+++ b/index.html
@@ -23,6 +23,15 @@
 
   <!-- Styles -->
   <link rel="stylesheet" href="css/style.css">
+
+  <!-- Prevent FOUC for theme -->
+  <script>
+    (function() {
+      const stored = localStorage.getItem('theme');
+      const preferred = stored || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+      document.documentElement.setAttribute('data-theme', preferred);
+    })();
+  </script>
 </head>
 <body>
   <header class="header">
@@ -32,6 +41,27 @@
         <li><a href="index.html" class="nav__link nav__link--active">Index</a></li>
         <li><a href="about.html" class="nav__link">About</a></li>
         <li><a href="research.html" class="nav__link">Research</a></li>
+        <li>
+          <button class="theme-toggle" id="theme-toggle" aria-label="Toggle dark mode">
+            <span class="theme-toggle__track"></span>
+            <span class="theme-toggle__thumb">
+              <svg class="theme-toggle__icon theme-toggle__icon--moon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+              </svg>
+              <svg class="theme-toggle__icon theme-toggle__icon--sun" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <circle cx="12" cy="12" r="5"/>
+                <line x1="12" y1="1" x2="12" y2="3" stroke="currentColor" stroke-width="2"/>
+                <line x1="12" y1="21" x2="12" y2="23" stroke="currentColor" stroke-width="2"/>
+                <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" stroke="currentColor" stroke-width="2"/>
+                <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" stroke="currentColor" stroke-width="2"/>
+                <line x1="1" y1="12" x2="3" y2="12" stroke="currentColor" stroke-width="2"/>
+                <line x1="21" y1="12" x2="23" y2="12" stroke="currentColor" stroke-width="2"/>
+                <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" stroke="currentColor" stroke-width="2"/>
+                <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" stroke="currentColor" stroke-width="2"/>
+              </svg>
+            </span>
+          </button>
+        </li>
       </ul>
     </nav>
   </header>

--- a/js/main.js
+++ b/js/main.js
@@ -5,6 +5,43 @@
 (function() {
   'use strict';
 
+  // Theme Toggle
+  const themeToggle = document.getElementById('theme-toggle');
+  const root = document.documentElement;
+
+  function getStoredTheme() {
+    return localStorage.getItem('theme');
+  }
+
+  function getPreferredTheme() {
+    const stored = getStoredTheme();
+    if (stored) return stored;
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  }
+
+  function setTheme(theme) {
+    root.setAttribute('data-theme', theme);
+    localStorage.setItem('theme', theme);
+  }
+
+  // Initialize theme
+  setTheme(getPreferredTheme());
+
+  // Toggle handler
+  if (themeToggle) {
+    themeToggle.addEventListener('click', () => {
+      const current = root.getAttribute('data-theme');
+      setTheme(current === 'dark' ? 'light' : 'dark');
+    });
+  }
+
+  // Listen for system preference changes
+  window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
+    if (!getStoredTheme()) {
+      setTheme(e.matches ? 'dark' : 'light');
+    }
+  });
+
   // Header hide/show on scroll
   const header = document.getElementById('header');
   let lastScrollY = window.scrollY;

--- a/research.html
+++ b/research.html
@@ -23,6 +23,15 @@
 
   <!-- Styles -->
   <link rel="stylesheet" href="css/style.css">
+
+  <!-- Prevent FOUC for theme -->
+  <script>
+    (function() {
+      const stored = localStorage.getItem('theme');
+      const preferred = stored || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+      document.documentElement.setAttribute('data-theme', preferred);
+    })();
+  </script>
 </head>
 <body>
   <header class="header">
@@ -32,6 +41,27 @@
         <li><a href="index.html" class="nav__link">Index</a></li>
         <li><a href="about.html" class="nav__link">About</a></li>
         <li><a href="research.html" class="nav__link nav__link--active">Research</a></li>
+        <li>
+          <button class="theme-toggle" id="theme-toggle" aria-label="Toggle dark mode">
+            <span class="theme-toggle__track"></span>
+            <span class="theme-toggle__thumb">
+              <svg class="theme-toggle__icon theme-toggle__icon--moon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+              </svg>
+              <svg class="theme-toggle__icon theme-toggle__icon--sun" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <circle cx="12" cy="12" r="5"/>
+                <line x1="12" y1="1" x2="12" y2="3" stroke="currentColor" stroke-width="2"/>
+                <line x1="12" y1="21" x2="12" y2="23" stroke="currentColor" stroke-width="2"/>
+                <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" stroke="currentColor" stroke-width="2"/>
+                <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" stroke="currentColor" stroke-width="2"/>
+                <line x1="1" y1="12" x2="3" y2="12" stroke="currentColor" stroke-width="2"/>
+                <line x1="21" y1="12" x2="23" y2="12" stroke="currentColor" stroke-width="2"/>
+                <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" stroke="currentColor" stroke-width="2"/>
+                <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" stroke="currentColor" stroke-width="2"/>
+              </svg>
+            </span>
+          </button>
+        </li>
       </ul>
     </nav>
   </header>


### PR DESCRIPTION
## Summary

Adds a dark mode variant using the Catppuccin Mocha color palette with a stylish toggle button in the header.

## Changes

- **CSS**: Added `[data-theme="dark"]` variables with Catppuccin Mocha colors
- **Toggle button**: Pill-shaped switch with animated moon/sun icons in the header nav
- **JavaScript**: Theme switching with localStorage persistence
- **System preference**: Respects `prefers-color-scheme: dark`
- **No FOUC**: Inline script in `<head>` applies theme before paint

## Preview

Toggle is located at the end of the navigation links. Theme preference persists across sessions.